### PR TITLE
Fix production white-screen crash (mui/emotion chunk TDZ)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -66,9 +66,6 @@ export default defineConfig({
       output: {
         manualChunks(id) {
           if (!id.includes('node_modules')) return undefined;
-          // MUI is only used by the lazily-loaded chat portal, so keep it
-          // out of the eagerly-loaded vendor chunk.
-          if (id.includes('@mui') || id.includes('@emotion')) return 'mui';
           if (id.includes('tsparticles')) return 'particles';
           if (id.includes('react-router')) return 'router';
           return 'vendor';


### PR DESCRIPTION
## Summary
- Production (www.jckail.com) currently renders a **blank white page** for all visitors. Root cause: `Cannot access 'qt' before initialization` thrown from the `mui` chunk at load time, crashing the React app before it ever mounts.
- The `mui` manual chunk (splitting `@mui`/`@emotion` out of `vendor`) creates a circular chunk dependency that Rollup orders incorrectly at runtime.
- Fix: merge `@mui`/`@emotion` back into the `vendor` chunk. Verified locally — built with sourcemaps, loaded in headless Chromium, confirmed the crash before the fix and a normal render after.

## Test plan
- [x] Local build + headless Chromium load: app renders (theme/resume logs fire, no pageerror) after the fix, crashes with blank page before it
- [ ] CI (Frontend lint/type-check/test/build) green
- [ ] Deploy workflow succeeds and www.jckail.com renders content post-merge