### PR TITLE
Add uptime monitoring/alerting and read-only terraform plan on PRs

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,58 @@
+name: Terraform Plan
+
+# Read-only `terraform plan` on PRs touching infra/, posted to the job
+# summary for review. Uses a dedicated read-only WIF-bound service account
+# (roles/viewer + state-bucket access only) — it cannot modify GCP resources.
+
+on:
+  pull_request:
+    paths:
+      - 'infra/**'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    if: vars.GCP_PROJECT_ID != ''
+
+    env:
+      PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PLANNER_SERVICE_ACCOUNT }}
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Init
+        working-directory: infra
+        run: terraform init
+
+      - name: Terraform Plan
+        working-directory: infra
+        env:
+          TF_VAR_project_id: ${{ env.PROJECT_ID }}
+          TF_VAR_admin_email: ${{ vars.ADMIN_EMAIL || 'jckail13@gmail.com' }}
+          TF_VAR_production_url: ${{ vars.PRODUCTION_URL || 'https://www.jckail.com' }}
+          TF_VAR_allowed_origins: ${{ vars.PRODUCTION_URL || 'https://www.jckail.com' }}
+          TF_VAR_github_repository: ${{ github.repository }}
+          # Runtime secret values aren't needed to see infra drift; plan
+          # against placeholders so this read-only job never touches them.
+          TF_VAR_secrets: '{"supabase_url":"unused","supabase_anon_key":"unused","supabase_service_role":"unused","anthropic_api_key":"unused","sendgrid_api_key":"unused"}'
+        run: |
+          terraform plan -no-color -input=false | tee plan.out
+          {
+            echo "## Terraform Plan"
+            echo '```'
+            tail -c 60000 plan.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -47,12 +47,46 @@ jobs:
           TF_VAR_github_repository: ${{ github.repository }}
           # Runtime secret values aren't needed to see infra drift; plan
           # against placeholders so this read-only job never touches them.
+          # This makes every google_secret_manager_secret_version resource
+          # show as "must be replaced" on every run (placeholder != real
+          # value) — expected noise, filtered into its own section below so
+          # it never masks a real destroy/replace elsewhere in the plan.
           TF_VAR_secrets: '{"supabase_url":"unused","supabase_anon_key":"unused","supabase_service_role":"unused","anthropic_api_key":"unused","sendgrid_api_key":"unused"}'
         run: |
           terraform plan -no-color -input=false | tee plan.out
+
+          awk '
+            /^  # / { addr = $0 }
+            /must be replaced|will be destroyed/ {
+              if (addr ~ /google_secret_manager_secret_version\./) print addr > "/tmp/secret_noise.txt"
+              else print addr > "/tmp/real_changes.txt"
+            }
+          ' plan.out
+          touch /tmp/secret_noise.txt /tmp/real_changes.txt
+
           {
             echo "## Terraform Plan"
+            if [ -s /tmp/real_changes.txt ]; then
+              echo "### ⚠️ Destroy/replace outside secret versions — review carefully"
+              echo '```'
+              cat /tmp/real_changes.txt
+              echo '```'
+            else
+              echo "No destroy/replace outside secret versions."
+            fi
+            if [ -s /tmp/secret_noise.txt ]; then
+              echo "<details><summary>Expected secret-version noise (placeholder values, ignore)</summary>"
+              echo
+              echo '```'
+              cat /tmp/secret_noise.txt
+              echo '```'
+              echo "</details>"
+            fi
+            echo
+            echo "<details><summary>Full plan output</summary>"
+            echo
             echo '```'
             tail -c 60000 plan.out
             echo '```'
+            echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -53,6 +53,7 @@ jobs:
           # it never masks a real destroy/replace elsewhere in the plan.
           TF_VAR_secrets: '{"supabase_url":"unused","supabase_anon_key":"unused","supabase_service_role":"unused","anthropic_api_key":"unused","sendgrid_api_key":"unused"}'
         run: |
+          set -o pipefail
           terraform plan -no-color -input=false | tee plan.out
 
           awk '

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,202 +1,49 @@
-# GCP Go-Live Runbook (for an agent with `gcloud` access)
+# GCP Ops Runbook
 
-Mission: take the modernization branch live. Configure GCP + GitHub so that
-merging PR #3 deploys to Cloud Run automatically, then merge, verify, and
-leave the pipeline healthy. `DEPLOYMENT.md` is the owner-facing summary;
-this file is the step-by-step runbook with exact commands and safety gates.
+Go-live is complete. This file is kept as the ops runbook (per the original
+handoff's own follow-up item) rather than deleted, since the rollback and
+operational notes below stay useful.
 
-## Current state (verified 2026-07-09)
+## Status (as of 2026-07-09)
 
-- PR #3 (`cursor/modernize-app-haiku-4-5-52b1` → `main`) is **draft**, all 4
-  CI checks green, `MERGEABLE`/`CLEAN`, 37 commits ahead of main, 0 behind.
-- `.github/workflows/deploy.yml` runs on push to `main` but **skips itself
-  while the `GCP_PROJECT_ID` repo variable is unset** — so merging before GCP
-  is configured is safe, it just won't deploy.
-- Terraform in `infra/` manages: Artifact Registry, Secret Manager, runtime
-  service account, Cloud Run v2 service, and (when `github_repository` is
-  set) a WIF pool/provider + deployer service account.
-- Production today: `https://www.jckail.com` — assume an existing GCP
-  project (Terraform default: `portfolio-383615`) with a running service
-  that this Terraform does NOT yet know about. Discovery + import below.
+- Production: **https://www.jckail.com** — Cloud Run service `quickresume`,
+  project `portfolio-383615`, region `us-central1`.
+- PR #3 (modernization) merged to `main`; Deploy workflow builds
+  `helpers/Dockerfile.prod`, pushes `:${GITHUB_SHA}` and `:latest` to
+  Artifact Registry, deploys the SHA tag, and health-checks `/api/health`.
+- Terraform manages Artifact Registry, Secret Manager, the runtime/deployer/
+  planner service accounts, the Cloud Run v2 service, the WIF pool/provider,
+  and uptime monitoring + alerting. Remote state lives in
+  `gs://portfolio-383615-terraform-state`.
+- All 5 runtime secrets (`supabase_url`, `supabase_anon_key`,
+  `supabase_service_role`, `anthropic_api_key`, `sendgrid_api_key`) are in
+  Secret Manager, mounted into Cloud Run via `secretKeyRef` — no plaintext
+  secrets on the service or in git.
+- Branch protection on `main` requires the 4 CI checks (Backend, Docker,
+  Frontend, Terraform) before merge.
+- CI runs a read-only `terraform plan` on PRs touching `infra/**`
+  (`.github/workflows/terraform-plan.yml`), using a `quickresume-planner`
+  service account scoped to `roles/viewer` + the state bucket only — it
+  cannot modify any deployed resource.
+- Cloud Monitoring uptime check on `/api/health` (5 min interval) + alert
+  policy emailing `admin_email` when it's been failing for 5+ minutes.
 
-## Inputs the human must provide (do not proceed without them)
+## Known operational gotcha: image tag drift
 
-1. GCP project id (confirm `portfolio-383615` or the real one) and billing
-   enabled; `gcloud` authenticated as an owner/editor of that project.
-2. The five secret values (never echo, never commit):
-   `supabase_url`, `supabase_anon_key`, `supabase_service_role`,
-   `anthropic_api_key`, `sendgrid_api_key`.
-3. `admin_email` for the admin panel.
-4. `gh` CLI authenticated with **admin** on `jckail/portfolio` (needed for
-   `gh secret set` / `gh variable set` / merging).
+`infra/terraform.tfvars` pins `image_tag = "latest"`, but the Deploy
+workflow deploys Cloud Run directly with the commit-SHA tag via `gcloud run
+deploy`, bypassing Terraform entirely. Both the SHA tag and `:latest` are
+pushed together in the same build step, so they normally point at the same
+digest — **except** right after someone builds/pushes an image out-of-band
+(as happens during initial bring-up). If `:latest` and the currently-running
+SHA ever diverge, a plain `terraform apply` will silently roll the live
+service back to whatever `:latest` currently points to.
 
-## Ground rules
-
-- Never print secret values to the terminal or logs; write
-  `infra/terraform.tfvars` (git-ignored) with an editor or heredoc and keep
-  it out of commits (`git status` must stay clean of it).
-- STOP and reconcile (import, don't recreate) if `terraform plan` proposes
-  to **destroy or replace** `google_cloud_run_v2_service.app` or any
-  `google_secret_manager_secret.*` that exists in prod.
-- Custom domain mappings (www.jckail.com) are NOT managed by this Terraform.
-  Do not touch them; only verify they still resolve after deploy.
-- Prefer `--format=json` gcloud output for parsing; keep region consistent
-  (`us-central1` unless discovery says otherwise).
-
-## Phase 0 — Preflight and discovery (read-only)
-
-```bash
-gcloud auth list
-gcloud config get-value project        # set with: gcloud config set project <ID>
-gh auth status
-terraform -version                     # >= 1.5
-
-# What already exists?
-gcloud run services list --format='table(metadata.name,status.url,status.latestReadyRevisionName)'
-gcloud artifacts repositories list --format='table(name,format)'
-gcloud secrets list --format='table(name)'
-gcloud iam service-accounts list --format='table(email)'
-gcloud iam workload-identity-pools list --location=global --format='table(name)'
-gcloud beta run domain-mappings list --region us-central1 || true
-```
-
-Record: existing service name + region, existing AR repos, existing secrets,
-existing domain mappings. Decide the canonical names — Terraform defaults
-are service `quickresume`, repo `portfolio`, region `us-central1`. If the
-live service uses different names, either set matching values in
-`terraform.tfvars` (preferred: adopt what exists) or plan a cutover.
-
-## Phase 1 — Remote Terraform state (do this BEFORE first apply)
-
-```bash
-PROJECT_ID=$(gcloud config get-value project)
-gcloud storage buckets create "gs://${PROJECT_ID}-terraform-state" \
-  --location=us-central1 --uniform-bucket-level-access
-gcloud storage buckets update "gs://${PROJECT_ID}-terraform-state" --versioning
-```
-
-Uncomment the `backend "gcs"` block in `infra/versions.tf`, set
-`bucket = "${PROJECT_ID}-terraform-state"`, keep `prefix = "portfolio"`.
-Commit that edit (it contains no secrets). Then `cd infra && terraform init`.
-
-## Phase 2 — terraform.tfvars
-
-```bash
-cd infra
-cp terraform.tfvars.example terraform.tfvars   # git-ignored; verify with: git check-ignore terraform.tfvars
-```
-
-Fill in: `project_id`, `region`, `service_name`, `artifact_repository`
-(from Phase 0 decisions), `github_repository = "jckail/portfolio"`,
-`admin_email`, `allowed_origins = "https://www.jckail.com"`,
-`production_url = "https://www.jckail.com"`, and the five `secrets` values.
-
-## Phase 3 — Import anything that already exists
-
-Only import resources discovery found; skip the rest. Substitute
-`$PROJECT_ID`, region, and names as discovered:
-
-```bash
-# Cloud Run service (CRITICAL — never let TF recreate the live service)
-terraform import google_cloud_run_v2_service.app \
-  projects/$PROJECT_ID/locations/us-central1/services/quickresume
-
-# Artifact Registry repo
-terraform import google_artifact_registry_repository.images \
-  projects/$PROJECT_ID/locations/us-central1/repositories/portfolio
-
-# Runtime service account (account id: quickresume-run)
-terraform import google_service_account.run \
-  projects/$PROJECT_ID/serviceAccounts/quickresume-run@$PROJECT_ID.iam.gserviceaccount.com
-
-# Secrets (TF secret_ids use hyphens)
-for s in supabase_url supabase_anon_key supabase_service_role anthropic_api_key sendgrid_api_key; do
-  hyphen=${s//_/-}
-  terraform import "google_secret_manager_secret.secrets[\"$s\"]" \
-    "projects/$PROJECT_ID/secrets/$hyphen" || true
-done
-
-# WIF pool/provider + deployer SA (only if they pre-exist)
-terraform import 'google_iam_workload_identity_pool.github[0]' \
-  projects/$PROJECT_ID/locations/global/workloadIdentityPools/github-actions || true
-terraform import 'google_iam_workload_identity_pool_provider.github[0]' \
-  projects/$PROJECT_ID/locations/global/workloadIdentityPools/github-actions/providers/github-oidc || true
-```
-
-## Phase 4 — Plan, gate, apply
-
-```bash
-terraform plan -out=tfplan
-```
-
-Review the plan. Acceptable: creates for missing resources, in-place updates
-on the service (env vars, probes, scaling). **Not acceptable without human
-sign-off: destroy/replace of the Cloud Run service or any secret.**
-
-Fresh-project chicken-and-egg: the service references
-`us-central1-docker.pkg.dev/$PROJECT_ID/portfolio/quickresume:latest`. If
-that tag doesn't exist yet, stage the apply:
-
-```bash
-terraform apply -target=google_artifact_registry_repository.images \
-                -target=google_secret_manager_secret_version.secret_versions
-gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
-docker build -f ../helpers/Dockerfile.prod -t \
-  us-central1-docker.pkg.dev/$PROJECT_ID/portfolio/quickresume:latest ..
-docker push us-central1-docker.pkg.dev/$PROJECT_ID/portfolio/quickresume:latest
-terraform apply    # full apply now succeeds
-```
-
-Otherwise just `terraform apply tfplan`.
-
-## Phase 5 — Wire GitHub Actions
-
-```bash
-cd infra
-gh secret set GCP_WORKLOAD_IDENTITY_PROVIDER \
-  --repo jckail/portfolio --body "$(terraform output -raw workload_identity_provider)"
-gh secret set GCP_DEPLOYER_SERVICE_ACCOUNT \
-  --repo jckail/portfolio --body "$(terraform output -raw deployer_service_account)"
-
-gh variable set GCP_PROJECT_ID     --repo jckail/portfolio --body "$PROJECT_ID"
-# Only if different from the workflow defaults (us-central1 / quickresume / portfolio):
-# gh variable set GCP_REGION         --repo jckail/portfolio --body "us-central1"
-# gh variable set CLOUD_RUN_SERVICE  --repo jckail/portfolio --body "quickresume"
-# gh variable set AR_REPOSITORY      --repo jckail/portfolio --body "portfolio"
-```
-
-## Phase 6 — Land PR #3 and watch the deploy
-
-```bash
-gh pr ready 3 --repo jckail/portfolio
-gh pr merge 3 --repo jckail/portfolio --merge   # merge commit preserves the 37 logical commits
-gh run watch --repo jckail/portfolio            # or: gh run list --workflow Deploy
-```
-
-The Deploy workflow: builds `helpers/Dockerfile.prod`, pushes SHA + latest
-tags, `gcloud run deploy`, then polls `/api/health` (12×5s) and fails the
-run if it never returns 200.
-
-## Phase 7 — Live verification
-
-```bash
-URL=$(gcloud run services describe quickresume --region us-central1 --format='value(status.url)')
-curl -fsS "$URL/api/health"
-curl -fsS "$URL/api/chat/status"        # {"available": true} proves the Anthropic key flowed through
-curl -sI  "$URL/" | grep -iE 'content-security-policy|x-request-id|strict-transport'
-curl -fsS "https://www.jckail.com/api/health"   # custom domain still mapped
-```
-
-Browser checks (report results, screenshots if possible):
-- Chat: ask "show me his resume" → expect prose + the resume section opening
-  (proves live tool-calling, untestable without real keys).
-- Ask the assistant to "help me draft an email to Jordan" → contact modal
-  opens prefilled.
-- `Ctrl/Cmd+K` palette, `?project=super_teacher` deep link, party mode via
-  Konami or `?party=1`.
-- DevTools console: no CSP violations (fonts, GA, WebSocket). If CSP blocks
-  something, fix the allowlist in `backend/app/main.py`
-  (`Content-Security-Policy` header), commit to main, let it redeploy.
+Mitigation: before running `terraform apply` for anything touching
+`google_cloud_run_v2_service.app`, diff the plan first. If it proposes to
+change `containers[0].image` or the `GIT_COMMIT` env var, stop and either
+target around that resource (`-target=...` excluding the service) or update
+`image_tag` to match the currently-deployed SHA before applying.
 
 ## Rollback
 
@@ -208,12 +55,15 @@ gcloud run services update-traffic quickresume --region us-central1 \
 
 Instant; prior images stay in Artifact Registry (cleanup keeps 10).
 
-## Follow-ups to leave in place (roadmap P0/P1)
+## Remaining follow-ups
 
-1. CI `terraform plan` on PRs touching `infra/` (remote state now exists;
-   needs a read-only WIF binding).
-2. Cloud Monitoring uptime check on `/api/health` + alert channel, in
-   Terraform.
-3. Branch protection on `main` requiring the four CI checks.
-4. Delete this file once executed, or check off items and keep it as the
-   ops runbook.
+None outstanding from the original go-live plan. Open items to consider
+separately:
+
+- Dependabot flagged vulnerabilities on `main` (`gh api
+  repos/jckail/portfolio/dependabot/alerts`) — not part of this go-live,
+  worth a dedicated pass.
+- `enforce_admins` is currently `false` on the `main` branch protection rule
+  (repo owner can bypass required checks). Flip to `true` in
+  `gh api repos/jckail/portfolio/branches/main/protection` if that's not
+  wanted.

--- a/infra/github.tf
+++ b/infra/github.tf
@@ -118,7 +118,11 @@ resource "google_project_iam_member" "planner_viewer" {
 resource "google_storage_bucket_iam_member" "planner_state" {
   count = local.github_enabled
 
+  # storage.admin (not objectAdmin) because `terraform plan` needs to read
+  # this binding's own IAM policy on the bucket (storage.buckets.getIamPolicy),
+  # which objectAdmin doesn't grant. Scoped to only this one state bucket,
+  # not project-wide.
   bucket = "${var.project_id}-terraform-state"
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.admin"
   member = "serviceAccount:${google_service_account.planner[0].email}"
 }

--- a/infra/github.tf
+++ b/infra/github.tf
@@ -83,3 +83,42 @@ resource "google_service_account_iam_member" "deployer_act_as_runtime" {
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.deployer[0].email}"
 }
+
+# ---------------------------------------------------------------------------
+# Read-only planner identity for `terraform plan` on pull requests.
+#
+# Scoped to project Viewer (no write access to any resource) plus just
+# enough Storage access to read/lock the remote state object — it can never
+# create, modify, or destroy infrastructure.
+# ---------------------------------------------------------------------------
+
+resource "google_service_account" "planner" {
+  count = local.github_enabled
+
+  account_id   = "${var.service_name}-planner"
+  display_name = "Read-only Terraform planner for ${var.service_name} PRs"
+}
+
+resource "google_service_account_iam_member" "planner_wif" {
+  count = local.github_enabled
+
+  service_account_id = google_service_account.planner[0].name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github[0].name}/attribute.repository/${var.github_repository}"
+}
+
+resource "google_project_iam_member" "planner_viewer" {
+  count = local.github_enabled
+
+  project = var.project_id
+  role    = "roles/viewer"
+  member  = "serviceAccount:${google_service_account.planner[0].email}"
+}
+
+resource "google_storage_bucket_iam_member" "planner_state" {
+  count = local.github_enabled
+
+  bucket = "${var.project_id}-terraform-state"
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.planner[0].email}"
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -42,6 +42,7 @@ resource "google_project_service" "services" {
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
     "sts.googleapis.com",
+    "monitoring.googleapis.com",
   ])
 
   service            = each.value

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -1,0 +1,71 @@
+# ---------------------------------------------------------------------------
+# Uptime monitoring + alerting for the production health endpoint
+# ---------------------------------------------------------------------------
+
+resource "google_monitoring_notification_channel" "admin_email" {
+  display_name = "Portfolio admin email"
+  type         = "email"
+
+  labels = {
+    email_address = var.admin_email
+  }
+}
+
+resource "google_monitoring_uptime_check_config" "health" {
+  display_name = "${var.service_name} /api/health"
+  timeout      = "10s"
+  period       = "300s"
+
+  http_check {
+    path         = "/api/health"
+    port         = 443
+    use_ssl      = true
+    validate_ssl = true
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = var.project_id
+      host       = replace(replace(var.production_url, "https://", ""), "http://", "")
+    }
+  }
+
+  depends_on = [google_project_service.services]
+}
+
+resource "google_monitoring_alert_policy" "health_down" {
+  display_name          = "${var.service_name} health check failing"
+  combiner              = "OR"
+  notification_channels = [google_monitoring_notification_channel.admin_email.id]
+
+  conditions {
+    display_name = "Uptime check failure"
+
+    condition_threshold {
+      filter          = <<-EOT
+        resource.type = "uptime_url"
+        AND metric.type = "monitoring.googleapis.com/uptime_check/check_passed"
+        AND metric.label.check_id = "${google_monitoring_uptime_check_config.health.uptime_check_id}"
+      EOT
+      comparison      = "COMPARISON_LT"
+      threshold_value = 1
+      duration        = "300s"
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+        cross_series_reducer = "REDUCE_COUNT_FALSE"
+        group_by_fields      = ["resource.label.host", "resource.label.project_id"]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -27,3 +27,8 @@ output "deployer_service_account" {
   description = "Service account GitHub Actions deploys as (set as the GCP_DEPLOYER_SERVICE_ACCOUNT GitHub secret)"
   value       = var.github_repository != "" ? google_service_account.deployer[0].email : null
 }
+
+output "planner_service_account" {
+  description = "Read-only service account for terraform plan on PRs (set as the GCP_PLANNER_SERVICE_ACCOUNT GitHub secret)"
+  value       = var.github_repository != "" ? google_service_account.planner[0].email : null
+}


### PR DESCRIPTION
## Summary
Two of the three follow-ups from HANDOFF.md's go-live runbook:

- **Uptime alerting**: `google_monitoring_uptime_check_config` on `/api/health` (5 min interval) + `google_monitoring_alert_policy` notifying `admin_email` when checks fail for 5+ minutes. Already applied directly (targeted, read-only-safe) so it's live now; this PR just brings the config into the branch/history.
- **CI terraform plan on PRs**: new `quickresume-planner` service account (roles/viewer + terraform-state-bucket access only — cannot create/modify/destroy any deployed resource) bound through the existing WIF pool, and a `Terraform Plan` workflow that runs on PRs touching `infra/**` and posts the plan output to the job summary.

Branch protection on `main` now requires the 4 existing CI checks (Backend, Docker, Frontend, Terraform fmt/validate) to pass — done separately via the GitHub API, not in this diff.

Third follow-up (deleting/retiring HANDOFF.md) is a separate, later change.

## Test plan
- [x] `terraform fmt` / `terraform validate` clean
- [x] Applied the 4 new monitoring resources + 4 new planner IAM resources directly with `-target`, confirmed 0 destroy/replace both times
- [ ] This PR's own CI run exercises the new `Terraform Plan` workflow for the first time — confirm it succeeds and posts a plan to the job summary