### PR TITLE
Add E2E smoke test against the built production image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,43 @@ jobs:
         severity: CRITICAL,HIGH
         exit-code: '1'
         ignore-unfixed: true
+
+    - name: Run container for E2E smoke test
+      run: |
+        docker run -d --name portfolio-e2e -p 18080:8080 \
+          -e PORT=8080 \
+          -e SUPABASE_URL=https://example.supabase.co \
+          -e SUPABASE_ANON_KEY=x -e SUPABASE_SERVICE_ROLE=x \
+          -e ALLOWED_ORIGINS=http://localhost:18080 -e PRODUCTION_URL=http://localhost:18080 \
+          -e ADMIN_EMAIL=test@example.com -e RESUME_FILE=JordanKailResume.pdf \
+          -e ANTHROPIC_API_KEY=x -e SENDGRID_API_KEY=x \
+          portfolio-ci:latest
+        for i in $(seq 1 20); do
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/ || true)
+          [ "$STATUS" = "200" ] && exit 0
+          sleep 1
+        done
+        echo "Container never became ready"
+        docker logs portfolio-e2e
+        exit 1
+
+    - name: Use Node.js 22
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+        cache-dependency-path: e2e/package-lock.json
+
+    - name: Install Playwright
+      working-directory: e2e
+      run: |
+        npm ci
+        npx playwright install --with-deps chromium
+
+    - name: Run E2E smoke test
+      working-directory: e2e
+      run: npx playwright test
+
+    - name: Tear down E2E container
+      if: always()
+      run: docker rm -f portfolio-e2e || true

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ frontend/coverage/
 frontend/*.local
 samplefrontend/node_modules/*
 
+# E2E
+e2e/node_modules/
+e2e/test-results/
+e2e/playwright-report/
+
 # Environment variables
 .env
 .env.*

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "portfolio-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "portfolio-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "portfolio-e2e",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Single smoke test run against the built production Docker image in CI.",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.1"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  retries: 1,
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:18080',
+  },
+});

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('page loads, all sections render, and chat opens', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveTitle(/Jordan Kail/);
+
+  for (const id of ['about', 'experience', 'projects', 'skills']) {
+    await expect(page.locator(`section#${id}`)).toBeAttached();
+  }
+
+  await page.getByRole('button', { name: 'Chat with AI' }).click();
+  await expect(
+    page.getByRole('heading', { name: /Jordan's AI Assistant/ })
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary
ROADMAP.md P2 item: a single Playwright test (page loads, sections render, chat opens) run against the built Docker image in CI, to catch integration regressions unit tests can't.

- New `e2e/` Playwright project (isolated `package.json`, not bundled into `frontend/`)
- Wired into the existing `docker` CI job as additional steps after the Trivy scan (not a separate job) — a failure here already blocks merges via the existing required "Docker (build production image)" status check, no branch-protection changes needed
- Container runs with dummy Supabase/Anthropic credentials; verified locally that the static shell and `/api/chat/status` don't need real ones (only DB-touching endpoints do)

## Test plan
- [x] Built the image locally, ran the container with dummy credentials, confirmed `/` returns 200 without real Supabase connectivity
- [x] Ran the Playwright test locally against that container — passed (and confirmed it fails correctly when the chat-header selector was ambiguous, before fixing it to target the dialog heading specifically)
- [x] `npm ci` works against the committed `e2e/package-lock.json`
- [ ] First real run happens in this PR's own CI