### PR TITLE
Deploy: verify new revision before promoting to live traffic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,23 +66,38 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
-    - name: Deploy to Cloud Run
+    # Deploy the new revision with zero live traffic, verify it directly
+    # via its own tagged URL, and only then promote to 100%. This closes
+    # the previous gap where `gcloud run deploy` routed all production
+    # traffic to the new revision *before* the health check ran — a
+    # broken image was briefly live. If verification fails here, no
+    # traffic is ever shifted and the prior revision keeps serving
+    # unaffected; rollback is documented in HANDOFF.md.
+    - name: Deploy new revision (no traffic yet)
       run: |
+        TAG="gh-${GITHUB_SHA::7}"
+        echo "TAG=$TAG" >> "$GITHUB_ENV"
         gcloud run deploy "$SERVICE" \
           --project "$PROJECT_ID" \
           --region "$REGION" \
           --image "${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY}/${SERVICE}:${GITHUB_SHA}" \
           --update-env-vars "GIT_COMMIT=${GITHUB_SHA}" \
+          --no-traffic \
+          --tag="$TAG" \
           --quiet
 
-    - name: Verify deployment
+    - name: Verify new revision before promoting
       run: |
-        URL=$(gcloud run services describe "$SERVICE" \
-          --project "$PROJECT_ID" --region "$REGION" \
-          --format 'value(status.url)')
-        echo "Service URL: $URL"
+        CANARY_URL=$(gcloud run services describe "$SERVICE" \
+          --project "$PROJECT_ID" --region "$REGION" --format=json \
+          | jq -r --arg TAG "$TAG" '.status.traffic[] | select(.tag == $TAG) | .url')
+        if [ -z "$CANARY_URL" ]; then
+          echo "Could not resolve the tagged revision URL for $TAG"
+          exit 1
+        fi
+        echo "Verifying new revision at: $CANARY_URL"
         for i in $(seq 1 12); do
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$URL/api/health" || true)
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$CANARY_URL/api/health" || true)
           if [ "$STATUS" = "200" ]; then
             echo "Health check passed"
             exit 0
@@ -90,5 +105,23 @@ jobs:
           echo "Attempt $i: health returned $STATUS; retrying in 5s..."
           sleep 5
         done
-        echo "Health check failed"
+        echo "Health check failed — leaving traffic on the previous revision"
         exit 1
+
+    - name: Promote new revision to 100% traffic
+      run: |
+        gcloud run services update-traffic "$SERVICE" \
+          --project "$PROJECT_ID" --region "$REGION" \
+          --to-latest --quiet
+
+    - name: Verify production traffic
+      run: |
+        URL=$(gcloud run services describe "$SERVICE" \
+          --project "$PROJECT_ID" --region "$REGION" \
+          --format 'value(status.url)')
+        STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$URL/api/health" || true)
+        if [ "$STATUS" != "200" ]; then
+          echo "Production health check failed after promotion ($STATUS)"
+          exit 1
+        fi
+        echo "Production healthy at $URL"


### PR DESCRIPTION
## Summary
ROADMAP.md P1 "canary/rollback strategy" item. Previously `gcloud run deploy` routed 100% of production traffic to the new revision immediately, then ran the health check — so a broken image was briefly live for real visitors before the check could catch it.

Now:
1. Deploy the new revision with `--no-traffic --tag=gh-<short-sha>`
2. Health-check the tagged revision's *own* URL directly (zero live traffic exposure)
3. Only if that passes: `gcloud run services update-traffic --to-latest` to promote
4. One more health check against the production URL after promotion

If step 2 fails, no traffic is ever shifted — the previous revision keeps serving 100% of traffic, untouched. One-command rollback was already documented in `HANDOFF.md`.

## Test plan
- [x] Manually dispatched this exact workflow (from this branch, via `gh workflow run --ref`) against the real production service to validate end-to-end before merging — not just reviewed the YAML
- [x] Confirmed all 4 new/changed steps succeeded: deploy-no-traffic, tagged-URL health check, promote, post-promotion check
- [x] Confirmed via `gcloud run services describe` that the new revision (`quickresume-00282-cir`) is serving 100% of traffic under the expected tag, and `https://www.jckail.com/api/health` returns 200