### PR TITLE
Add ADRs and CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+Notable changes to the portfolio app and its infrastructure. Format
+loosely follows [Keep a Changelog](https://keepachangelog.com/); this
+project doesn't cut version tags, so entries are grouped by date instead.
+
+## Unreleased
+
+### Fixed
+- Production white-screen crash: the `mui`/`@emotion` Rollup manual
+  chunk had a circular chunk dependency causing `Cannot access 'qt'
+  before initialization` at load time, blanking the entire page for
+  every visitor. Merged that chunk back into `vendor`.
+- Flaky test `test_hashed_assets_are_immutable_and_gzipped`: picked an
+  arbitrary (unsorted) built JS file that could fall under GZipMiddleware's
+  1KB compression threshold. Now picks the largest chunk.
+
+### Added
+- Terraform-managed infrastructure on GCP: Cloud Run, Artifact Registry,
+  Secret Manager, Workload Identity Federation for keyless GitHub Actions
+  deploys, remote state in GCS.
+- Cloud Monitoring uptime check on `/api/health` + email alert policy.
+- CI: coverage gates (vitest + pytest, modest floors below current
+  numbers), Trivy image vulnerability scanning (fails on fixable
+  CRITICAL/HIGH CVEs), a read-only `terraform plan` job on PRs touching
+  `infra/**`, and a Playwright E2E smoke test against the built image.
+- Deploy pipeline now deploys new revisions with zero traffic, verifies
+  the tagged revision directly, and only promotes to 100% traffic if
+  healthy — a broken image is never live.
+- `requirements.lock.txt`: hash-pinned dependencies so the production
+  Docker image installs reproducibly (`pip install --require-hashes`).
+- Branch protection on `main` requiring the 4 CI checks.
+- `docs/adr/`: architecture decision records for the WebSocket chat
+  transport, Supabase, Cloud Run, and the deploy-verify-promote pattern.
+
+### Changed
+- Production base image `python:3.12.3-slim` → `python:3.12-slim` (patch
+  version unpinned to track Debian's security-patched slim builds) plus
+  pinned `setuptools`/`wheel` versions, closing several fixable CVEs.
+
+## 2026-07-08 — Modernization
+
+Claude Haiku 4.5 assistant with conversation memory, prompt caching, and
+tool-calling (site navigation, resume download, contact-form prefill);
+command palette; interactive doodle canvas with party mode; project/skill/
+experience detail modals with shareable deep links; cookie consent;
+backend pytest suite; structured JSON logging with request IDs; CSP and
+other security headers; optimized images (11 MB → 1.1 MB); initial
+Terraform IaC and CI/CD pipeline. See `ROADMAP.md` for the full list.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -132,10 +132,10 @@ CI/CD pipeline that deploys to Cloud Run on merge to `main`.
 
 - ~~**P1 — Architecture diagram.**~~ Done: mermaid diagram in the root README
   covering SPA → FastAPI → Claude/Supabase/SendGrid and the deploy path.
-- **P2 — ADRs.** Record decisions (WebSockets vs SSE for chat, Supabase,
-  Cloud Run) as lightweight Architecture Decision Records in `docs/`.
-- **P2 — Changelog.** Adopt a `CHANGELOG.md` maintained per release once
-  the deploy pipeline is in regular use.
+- ~~**P2 — ADRs.**~~ Done: `docs/adr/` covers WebSockets vs SSE for chat,
+  Supabase, Cloud Run, and the deploy-verify-promote pattern.
+- ~~**P2 — Changelog.**~~ Done: `CHANGELOG.md`, grouped by date rather
+  than version tags since this project doesn't cut releases.
 
 ## 7. Visitor-facing product features
 
@@ -181,8 +181,9 @@ CI/CD pipeline that deploys to Cloud Run on merge to `main`.
 2. ~~**User-facing polish:** assistant UX, project modals, skills search,
    About CTA, chat navigation tools, doodle canvas, cookie consent, focus
    trap, keyboard shortcuts.~~ Done.
-3. **Platform maturity (current focus):** coverage gates, image
-   vulnerability scanning, reproducible Python builds, canary deploys.
-   CSP and architecture diagram already done.
-4. **Bigger bets:** staging environment, CDN, OpenTelemetry, PWA offline
-   shell, usage telemetry, E2E smoke test, Lighthouse CI budgets.
+3. ~~**Platform maturity:** coverage gates, image vulnerability scanning,
+   reproducible Python builds, canary deploys, E2E smoke test, ADRs,
+   changelog.~~ Done.
+4. **Bigger bets (current focus):** staging environment, CDN,
+   OpenTelemetry, PWA offline shell, usage telemetry, Lighthouse CI
+   budgets, responsive images, persisted chat transcripts per session.

--- a/docs/adr/0001-websockets-for-chat.md
+++ b/docs/adr/0001-websockets-for-chat.md
@@ -1,0 +1,36 @@
+# 0001: WebSockets (not SSE) for the chat assistant
+
+**Status:** Accepted (reflects the current implementation)
+
+## Context
+
+The chat assistant needs to stream tokens from Claude to the browser as
+they arrive, plus send the occasional non-text frame (`{"type":"action"}`
+for `navigate_section`/`open_modal`/`download_resume`/`prefill_contact`,
+history replay after reconnect, rate-limit notices). Two natural options:
+Server-Sent Events (one-way HTTP stream, client sends new messages via a
+separate POST) or a single WebSocket connection for both directions.
+
+## Decision
+
+Use a WebSocket per chat session (`backend/app/api/chat_routes.py`,
+mounted under `/ws`), with a `ConnectionManager` in
+`services/chat_service.py` holding per-connection state (history,
+context, rate-limit counters).
+
+## Consequences
+
+- One connection carries both the streamed assistant response and
+  structured action frames — no separate channel or polling needed for
+  the frontend to receive `{"type":"action"}` navigation events.
+- Server-side state (conversation history, rate limiting) lives in the
+  `ConnectionManager` keyed by `client_id`, scoped to the connection's
+  lifetime — simpler than correlating a stateless SSE stream with
+  separate POST requests.
+- Cost: WebSockets need explicit reconnect/backoff handling on the
+  client (`useChat.ts`) and don't work through every restrictive proxy —
+  SSE degrades more gracefully over plain HTTP. Not a concern for this
+  service's ingress.
+- Cloud Run supports WebSockets natively (session affinity via the
+  `run.googleapis.com` connection), so no additional infrastructure was
+  needed to keep this working.

--- a/docs/adr/0002-supabase-for-data-and-auth.md
+++ b/docs/adr/0002-supabase-for-data-and-auth.md
@@ -1,0 +1,30 @@
+# 0002: Supabase for data, auth, and chat logging
+
+**Status:** Accepted (reflects the current implementation)
+
+## Context
+
+The backend needs: a place to persist chat transcripts and telemetry
+events, admin authentication for `/api/admin/*`, and structured queries
+without standing up and operating a separate database service.
+
+## Decision
+
+Use Supabase (`backend/app/utils/supabase_client.py`) as the Postgres
+backend, accessed through its Python client with both an anon key
+(RLS-scoped reads) and a service-role key (server-side writes/admin
+queries) — never exposing the service-role key to the browser.
+
+## Consequences
+
+- No self-managed database: no Cloud SQL instance, connection pooling,
+  or backup schedule to operate for a project at this scale.
+- `/api/health` treats "can query the `logs` table" as the DB health
+  signal — a Supabase outage or misconfigured credentials directly fails
+  the health check (and therefore the CI/CD deploy gate and the uptime
+  alert), which is intentional: the site depends on it.
+- Two credential tiers (anon vs. service-role) require care to keep the
+  service-role key server-side only — it lives in Secret Manager, never
+  in a frontend bundle or GitHub Actions log.
+- Ties the project to Supabase's availability and pricing; acceptable
+  for current traffic, would need reassessment at a much larger scale.

--- a/docs/adr/0003-cloud-run-for-hosting.md
+++ b/docs/adr/0003-cloud-run-for-hosting.md
@@ -1,0 +1,33 @@
+# 0003: Cloud Run over GKE/App Engine for hosting
+
+**Status:** Accepted (reflects the current implementation)
+
+## Context
+
+The app is a single FastAPI service serving both the API and the built
+SPA (`frontend/dist` mounted as static files). It needs to run
+containerized, scale to zero when idle (a personal portfolio has bursty,
+low-baseline traffic), and support WebSocket connections for the chat
+assistant.
+
+## Decision
+
+Deploy as a single Cloud Run v2 service (`infra/main.tf`), built from
+`helpers/Dockerfile.prod` and pushed to Artifact Registry, authenticated
+via Workload Identity Federation from GitHub Actions (no service-account
+keys).
+
+## Consequences
+
+- Scale-to-zero (`min_instances = 0`) means near-zero cost during idle
+  periods, at the expense of cold-start latency on the first request
+  after a quiet period.
+- No cluster to operate (unlike GKE) — Cloud Run manages the container
+  runtime, TLS, and autoscaling. Trade-off: less control over networking
+  primitives than GKE would offer, which this project doesn't need.
+- WebSockets work natively; no separate load balancer or sticky-session
+  configuration was required.
+- One service currently serves both static assets and the API. Fronting
+  static assets with Cloud CDN or a separate storage-backed origin
+  (ROADMAP.md "CDN for static assets") would reduce global latency but
+  isn't done yet — not needed at current traffic.

--- a/docs/adr/0004-deploy-verify-before-promote.md
+++ b/docs/adr/0004-deploy-verify-before-promote.md
@@ -1,0 +1,32 @@
+# 0004: Deploy with zero traffic, verify, then promote
+
+**Status:** Accepted (2026-07)
+
+## Context
+
+The original `deploy.yml` ran `gcloud run deploy` (which by default
+routes 100% of traffic to the new revision immediately) and *then* health
+-checked it. If the new image was broken, real visitors could hit it
+before the check caught the problem and failed the workflow — the
+previous revision was never brought back automatically.
+
+## Decision
+
+Deploy the new revision with `--no-traffic --tag=gh-<short-sha>`, health
+-check that revision's own tagged URL directly (zero live-traffic
+exposure), and only run `gcloud run services update-traffic --to-latest`
+if that check passes. A final health check confirms the production URL
+after promotion.
+
+## Consequences
+
+- A failed deploy never serves real traffic — the previous revision keeps
+  serving 100% throughout, with no manual intervention needed.
+- Adds one extra `gcloud` round-trip (health-checking a revision-specific
+  URL) to every deploy, a few seconds of added CI time.
+- Rollback if a *promoted* revision turns out to be bad in ways the
+  health check didn't catch is still manual:
+  `gcloud run services update-traffic quickresume --to-revisions
+  <PREVIOUS_REVISION>=100` (documented in `HANDOFF.md`).
+- Verified end-to-end via manual `workflow_dispatch` against the live
+  service before merging, not just reviewed as YAML.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+Lightweight records of decisions worth remembering the *why* behind, not
+just the *what* (the code already shows the what). New ADRs: copy the
+format below, number sequentially, keep it to half a page.
+
+| ADR | Title |
+|---|---|
+| [0001](0001-websockets-for-chat.md) | WebSockets (not SSE) for the chat assistant |
+| [0002](0002-supabase-for-data-and-auth.md) | Supabase for data, auth, and chat logging |
+| [0003](0003-cloud-run-for-hosting.md) | Cloud Run over GKE/App Engine for hosting |
+| [0004](0004-deploy-verify-before-promote.md) | Deploy with zero traffic, verify, then promote |


### PR DESCRIPTION
Docs-only. ROADMAP.md P2 items: architecture decision records for the WebSocket chat transport, Supabase, Cloud Run, and this session's deploy-verify-promote change; a CHANGELOG.md grouped by date.