### PR TITLE
Log chat token usage and cache hit rates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,9 +50,11 @@ CI/CD pipeline that deploys to Cloud Run on merge to `main`.
   to `sessionStorage` and restored on reload within the same tab session.
 - ~~**P1 — Suggested prompts.**~~ Done: four clickable starter questions
   appear until the visitor sends their first message.
-- **P2 — Usage telemetry.** Log token counts and cache-hit rates from the
-  Anthropic responses (already available in the stream events) to Supabase
-  so cost and cache effectiveness are observable.
+- ~~**P2 — Usage telemetry.**~~ Done: token counts and cache hit/creation
+  counts logged to Supabase's existing `logs` table (`session_uuid` =
+  `client_id`, `source="chat"`, counts in `metadata`) after each response
+  — no schema change needed, reused the flexible metadata column instead
+  of a new table.
 - ~~**P2 — Tool use.**~~ Done, see §7 "Chat site-navigation actions."
 
 ## 3. Frontend performance & UX

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -213,6 +213,28 @@ class ConnectionManager:
         except Exception as e:
             logger.error("Error sending action to client %s: %s", client_id, e)
 
+    async def _log_usage(self, client_id: str, usage) -> None:
+        """Log token counts and cache-hit rates for cost/cache observability.
+
+        Uses the existing flexible `logs` table (via `session_uuid` +
+        `metadata`) rather than a new table/columns — `client_id` is used
+        as the session key instead of the GA session id since it's always
+        present, unlike GA (gated behind cookie consent).
+        """
+        await supabase.store_log(
+            level="INFO",
+            message="chat_completion_usage",
+            session_uuid=client_id,
+            source="chat",
+            metadata={
+                "model": CHAT_MODEL,
+                "input_tokens": getattr(usage, "input_tokens", None),
+                "output_tokens": getattr(usage, "output_tokens", None),
+                "cache_creation_input_tokens": getattr(usage, "cache_creation_input_tokens", None),
+                "cache_read_input_tokens": getattr(usage, "cache_read_input_tokens", None),
+            },
+        )
+
     async def _dispatch_tool_actions(self, client_id: str, final_message) -> list[str]:
         """Parse tool_use blocks, send action frames, return human labels."""
         labels: list[str] = []
@@ -271,6 +293,10 @@ class ConnectionManager:
                 is_chunk=False
             )
             return
+
+        usage = getattr(final_message, "usage", None)
+        if usage is not None:
+            await self._log_usage(client_id, usage)
 
         action_labels: list[str] = []
         if final_message is not None:

--- a/backend/tests/test_chat_ws.py
+++ b/backend/tests/test_chat_ws.py
@@ -7,9 +7,10 @@ from backend.app.services import chat_service
 
 
 class FakeStream:
-    def __init__(self, chunks, tool_uses=None):
+    def __init__(self, chunks, tool_uses=None, usage=None):
         self._chunks = chunks
         self._tool_uses = tool_uses or []
+        self._usage = usage
 
     @property
     def text_stream(self):
@@ -21,16 +22,17 @@ class FakeStream:
 
     async def get_final_message(self):
         content = list(self._tool_uses)
-        return SimpleNamespace(content=content)
+        return SimpleNamespace(content=content, usage=self._usage)
 
 
 class FakeStreamContext:
-    def __init__(self, chunks, tool_uses=None):
+    def __init__(self, chunks, tool_uses=None, usage=None):
         self._chunks = chunks
         self._tool_uses = tool_uses
+        self._usage = usage
 
     async def __aenter__(self):
-        return FakeStream(self._chunks, self._tool_uses)
+        return FakeStream(self._chunks, self._tool_uses, self._usage)
 
     async def __aexit__(self, exc_type, exc, tb):
         return False
@@ -39,19 +41,20 @@ class FakeStreamContext:
 class FakeMessages:
     """Stands in for AsyncAnthropic().messages, capturing call kwargs."""
 
-    def __init__(self, chunks, tool_uses=None):
+    def __init__(self, chunks, tool_uses=None, usage=None):
         self._chunks = chunks
         self._tool_uses = tool_uses or []
+        self._usage = usage
         self.calls = []
 
     def stream(self, **kwargs):
         # Deep-copy: the manager mutates the history list after this call
         self.calls.append(copy.deepcopy(kwargs))
-        return FakeStreamContext(self._chunks, self._tool_uses)
+        return FakeStreamContext(self._chunks, self._tool_uses, self._usage)
 
 
-def make_fake_anthropic(chunks, tool_uses=None):
-    messages = FakeMessages(chunks, tool_uses=tool_uses)
+def make_fake_anthropic(chunks, tool_uses=None, usage=None):
+    messages = FakeMessages(chunks, tool_uses=tool_uses, usage=usage)
     return SimpleNamespace(messages=messages), messages
 
 
@@ -217,3 +220,61 @@ def test_websocket_emits_action_frames_for_tool_use(client, monkeypatch):
         for f in frames
     )
     assert messages.calls[0].get("tools")  # tools were offered to the model
+
+
+def test_websocket_logs_token_usage_after_response(client, monkeypatch):
+    usage = SimpleNamespace(
+        input_tokens=120,
+        output_tokens=45,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=80,
+    )
+    fake_client, _ = make_fake_anthropic(["Hi there!"], usage=usage)
+    monkeypatch.setattr(chat_service.manager, "client", fake_client)
+
+    logged_calls = []
+
+    async def fake_store_log(**kwargs):
+        logged_calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(chat_service.supabase, "store_log", fake_store_log)
+
+    with client.websocket_connect("/ws/ws-test-usage") as ws:
+        ws.send_text(json.dumps({"type": "message", "content": "Hello"}))
+        while True:
+            frame = ws.receive_json()
+            if not frame.get("is_chunk", True):
+                break
+
+    assert len(logged_calls) == 1
+    call = logged_calls[0]
+    assert call["session_uuid"] == "ws-test-usage"
+    assert call["source"] == "chat"
+    assert call["metadata"]["input_tokens"] == 120
+    assert call["metadata"]["output_tokens"] == 45
+    assert call["metadata"]["cache_read_input_tokens"] == 80
+    assert call["metadata"]["cache_creation_input_tokens"] == 0
+
+
+def test_websocket_skips_usage_log_when_usage_absent(client, monkeypatch):
+    """Existing FakeStream default (usage=None) must not raise or log."""
+    fake_client, _ = make_fake_anthropic(["No usage data."])
+    monkeypatch.setattr(chat_service.manager, "client", fake_client)
+
+    logged_calls = []
+
+    async def fake_store_log(**kwargs):
+        logged_calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(chat_service.supabase, "store_log", fake_store_log)
+
+    with client.websocket_connect("/ws/ws-test-no-usage") as ws:
+        ws.send_text(json.dumps({"type": "message", "content": "Hello"}))
+        while True:
+            frame = ws.receive_json()
+            if not frame.get("is_chunk", True):
+                break
+
+    assert logged_calls == []


### PR DESCRIPTION
## Summary
ROADMAP.md P2 item. After each assistant response, log Anthropic's token counts and cache creation/read counts (already available on `stream.get_final_message().usage`) so cost and prompt-cache effectiveness are observable.

- Reuses the existing `logs` table (`session_uuid`, `source`, `metadata` JSON) instead of a new table/schema change — no Supabase migration needed
- Uses `client_id` (the WebSocket connection id, always present) as the session key rather than `google_analytics_session_id`, which is gated behind the site's cookie-consent banner and would silently drop telemetry for any visitor who hasn't opted into analytics yet — a real gap in how `store_chat_message` already works, not something I'm inventing

## Test plan
- [x] Bug caught while implementing: `final_message.usage` (no `getattr` guard) would have raised `AttributeError` against every existing chat test, since the test double's `SimpleNamespace` has no `usage` attribute — would have broken the whole suite silently until CI ran it. Fixed with `getattr(final_message, "usage", None)`.
- [x] Added two new tests: usage gets logged with correct fields when present, and nothing is logged (no crash) when `usage` is absent
- [x] Full backend suite: 43 passed, 2 skipped, ruff clean, coverage 62.8% (above the 60% gate)