### PR TITLE
Fix GA4 double-counted pageviews on section/anchor navigation

### DIFF
--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -60,17 +60,20 @@ const App: React.FC = () => {
     initAnalytics();
   }, []);
 
-  // Track both pathname and hash changes
+  // Track both pathname and hash changes.
+  //
+  // Exactly one of these fires per navigation, not both: trackAnchorChange
+  // already sends its own page_view (needed since useScrollSpy calls it
+  // directly, bypassing this effect), so also calling trackPageView for
+  // the same location would double-count the pageview in GA4.
   useEffect(() => {
     const trackNavigation = async () => {
       try {
-        // Track page view with full path
-        await trackPageView(location.pathname);
-        
-        // If there's a hash, track it as an anchor change
         if (location.hash) {
           const newAnchor = location.hash.slice(1); // Remove the # symbol
           await trackAnchorChange(newAnchor);
+        } else {
+          await trackPageView(location.pathname);
         }
       } catch (error) {
         console.error('Failed to track navigation:', error);

--- a/frontend/src/shared/utils/analytics.test.ts
+++ b/frontend/src/shared/utils/analytics.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-import { getSessionId, trackPageView } from './analytics';
+import { getSessionId, trackPageView, trackAnchorChange, trackSectionView } from './analytics';
 import { COOKIE_CONSENT_KEY } from './cookie-consent';
 
 describe('analytics', () => {
@@ -70,6 +70,38 @@ describe('analytics', () => {
       await vi.advanceTimersByTimeAsync(6000);
       await expect(pending).resolves.toBeUndefined();
       vi.useRealTimers();
+    });
+  });
+
+  describe('page_view double-counting', () => {
+    // trackAnchorChange and trackSectionView are always called together
+    // for the same section transition (see useScrollSpy); only one of
+    // them should ever send a page_view, or GA4 pageview counts get
+    // inflated ~2x for every scroll-driven section change.
+
+    it('trackAnchorChange sends exactly one page_view', async () => {
+      await trackAnchorChange('projects', 'about');
+      const pageViewCalls = (window.gtag as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call) => call[1] === 'page_view'
+      );
+      expect(pageViewCalls).toHaveLength(1);
+    });
+
+    it('trackSectionView does not send its own page_view', async () => {
+      await trackSectionView('projects');
+      const pageViewCalls = (window.gtag as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call) => call[1] === 'page_view'
+      );
+      expect(pageViewCalls).toHaveLength(0);
+    });
+
+    it('one section transition (both functions called together) sends exactly one page_view', async () => {
+      await trackAnchorChange('projects', 'about');
+      await trackSectionView('projects');
+      const pageViewCalls = (window.gtag as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call) => call[1] === 'page_view'
+      );
+      expect(pageViewCalls).toHaveLength(1);
     });
   });
 });

--- a/frontend/src/shared/utils/analytics.ts
+++ b/frontend/src/shared/utils/analytics.ts
@@ -218,6 +218,11 @@ export const trackPageView = async (path: string): Promise<void> => {
 };
 
 // Track section view
+//
+// Deliberately does NOT also send a page_view: this is always called
+// together with trackAnchorChange for the same section transition
+// (see useScrollSpy), which already sends one for the same page_path.
+// A duplicate here was inflating GA4 pageview counts.
 export const trackSectionView = async (sectionId: string): Promise<void> => {
   await waitForGtag();
   const sessionId = getSessionId();
@@ -226,21 +231,13 @@ export const trackSectionView = async (sectionId: string): Promise<void> => {
     category: 'Unknown Section',
     type: 'Custom Section'
   };
-  const fullPath = getFullPagePath();
-  
+
   safeGtagCall('event', 'section_view', {
     section_id: sectionId,
     section_title: metadata.title,
     section_category: metadata.category,
     section_type: metadata.type,
-    page_path: fullPath,
-    session_id: sessionId
-  });
-
-  // Also send a page_view event to ensure it shows up in GA realtime
-  safeGtagCall('event', 'page_view', {
-    page_path: fullPath,
-    page_title: metadata.title,
+    page_path: getFullPagePath(),
     session_id: sessionId
   });
 };


### PR DESCRIPTION
## Summary
User asked me to improve the Google Analytics implementation, so I audited `analytics.ts` end-to-end. Found a real, confirmable bug: two independent sources of double-counted `page_view` events in GA4.

1. **`trackSectionView`** fired its own extra `page_view` "to ensure it shows up in GA realtime" — but `useScrollSpy` always calls it together with `trackAnchorChange` for the same transition, which already sends one for the same `page_path`. Every scroll-driven section change sent 2 `page_view`s instead of 1.
2. **`app.tsx`'s navigation effect** called both `trackPageView(pathname)` *and* `trackAnchorChange(hash)` whenever the location had a hash — but `trackAnchorChange` already sends its own `page_view`. Every React-Router-driven navigation to a hash URL double-counted too.

Net effect in production: pageview/session metrics in GA4 have been inflated roughly 2x for most navigation on this site.

## Test plan
- [x] Added 3 new unit tests asserting exactly one `page_view` fires per section transition (`trackAnchorChange` + `trackSectionView` called together, matching real usage)
- [x] Full frontend suite: 63 passed, lint/tsc clean
- [x] **Verified live**, not just unit tests: built the production image, loaded it in a real browser with GA consent pre-granted, intercepted `dataLayer.push` to count actual events. Confirmed a scroll-driven section transition now fires exactly 1 `page_view` (was 2 before the fix). Also confirmed the 2 *legitimately different* page_views seen right after initial load (bare `/` then `/#about` as scroll-spy settles onto the initial section) are not duplicates of the same state — left that behavior untouched.
- [x] `trackModalView` keeps its own `page_view` send — nothing else fires `page_view` when a modal opens, so no duplication there. (Also currently dead code / never called anywhere in the app — out of scope for this fix, noted for a future cleanup pass.)